### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LFLAGS?=-L$(HTSTMP)
 # define any libraries to link into executable:
 #   if I want to link in libraries (libx.so or libx.a) I use the -llibname
 #   option, something like (this will link in libmylib.so and libm.so:
-LIBS =-lhts -lpthread -lz -lm -ldl
+LIBS =-lhts -lpthread -lz -lm -ldl -llzma -lbz2
 
 # define the C source files
 SRCS = ./src/file_tests.c ./src/List.c ./src/List_algos.c ./src/bam_access.c ./src/config_file_access.c ./src/fai_access.c ./src/ignore_reg_access.c ./src/alg_bean.c ./src/split_access.c ./src/covs_access.c ./src/cn_access.c ./src/genotype.c ./src/algos.c ./src/output.c ./src/setup.c ./src/split.c ./src/mstep.c ./src/merge.c ./src/estep.c


### PR DESCRIPTION
Added dependencies for `liblzma` and `libbzip2` without which this project does not compile (with the latest htslib).

```
./caveman_tmp/libhts.a(cram_io.o): In function `lzma_mem_deflate':
/home/sm2030/htslib/cram/cram_io.c:679: undefined reference to `lzma_stream_buffer_bound'
/home/sm2030/htslib/cram/cram_io.c:685: undefined reference to `lzma_easy_buffer_encode'
./caveman_tmp/libhts.a(cram_io.o): In function `cram_compress_by_method':
/home/sm2030/htslib/cram/cram_io.c:1062: undefined reference to `BZ2_bzBuffToBuffCompress'
./caveman_tmp/libhts.a(cram_io.o): In function `cram_uncompress_block':
/home/sm2030/htslib/cram/cram_io.c:982: undefined reference to `BZ2_bzBuffToBuffDecompress'
./caveman_tmp/libhts.a(cram_io.o): In function `lzma_mem_inflate':
/home/sm2030/htslib/cram/cram_io.c:701: undefined reference to `lzma_easy_decoder_memusage'
/home/sm2030/htslib/cram/cram_io.c:701: undefined reference to `lzma_stream_decoder'
/home/sm2030/htslib/cram/cram_io.c:719: undefined reference to `lzma_code'
/home/sm2030/htslib/cram/cram_io.c:732: undefined reference to `lzma_code'
/home/sm2030/htslib/cram/cram_io.c:743: undefined reference to `lzma_end'
/home/sm2030/htslib/cram/cram_io.c:748: undefined reference to `lzma_end'
/home/sm2030/htslib/cram/cram_io.c:743: undefined reference to `lzma_end'
collect2: error: ld returned 1 exit status
```

After adding `-llzma` only:
```
./caveman_tmp/libhts.a(cram_io.o): In function `cram_compress_by_method':
/home/sm2030/htslib/cram/cram_io.c:1062: undefined reference to `BZ2_bzBuffToBuffCompress'
./caveman_tmp/libhts.a(cram_io.o): In function `cram_uncompress_block':
/home/sm2030/htslib/cram/cram_io.c:982: undefined reference to `BZ2_bzBuffToBuffDecompress'
collect2: error: ld returned 1 exit status
```