### PR TITLE
Fix uninitialized memory read and free of memory not in heap.

### DIFF
--- a/src/generateCavemanVCFUnmatchedNormalPanel.c
+++ b/src/generateCavemanVCFUnmatchedNormalPanel.c
@@ -316,7 +316,6 @@ List *gen_panel_get_list_of_samples_and_locs(){
 		sampchar = strtok(NULL,",");
 		List_push(samples,this_samp);
 	}
-	free(sampchar);
 
 	bamchar = strtok(bam_file_locs,",");
 	LIST_FOREACH(samples, first, next, cur){

--- a/src/generateCavemanVCFUnmatchedNormalPanel.c
+++ b/src/generateCavemanVCFUnmatchedNormalPanel.c
@@ -303,7 +303,7 @@ List *gen_panel_get_list_of_samples_and_locs(){
 	char *bamchar = NULL;
 	samples = List_create();
 	//Iterate through list of sample_names using comma as separator
-	char *new_sample_names = malloc((strlen(sample_names)+1) * sizeof(char));
+	char *new_sample_names = calloc((strlen(sample_names)+1), sizeof(char));
 	check_mem(new_sample_names);
 	sampchar = strtok(sample_names,",");
 	while(sampchar != NULL){


### PR DESCRIPTION
This branch fixes two bugs in gen_panel_get_list_of_samples_and_locs.

1. Uninitialized memory is allocated and subsequently read, causing a buffer overrun on my system. This is fixed in the first commit.
2. There is an attempt to free memory that is not allocated on the heap. This is fixed in the second commit.